### PR TITLE
Unity no longer Unity3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DeferredShading
 ===============
 
-A DX11 Tiled Deferred Shading Renderer in Unity3D
+A DX11 Tiled Deferred Shading Renderer in Unity
 
 ![alt tag](http://i.imgur.com/wRq9ccI.png)
 


### PR DESCRIPTION
Unity long ago stated they would not like to be referenced as Unity3D, making this change to honor that and because they have branched out to support plenty of 2D games, VR and more.